### PR TITLE
Return data in native format for getOrtvalue()

### DIFF
--- a/lib/src/flutter_onnxruntime_method_channel.dart
+++ b/lib/src/flutter_onnxruntime_method_channel.dart
@@ -110,11 +110,8 @@ class MethodChannelFlutterOnnxruntime extends FlutterOnnxruntimePlatform {
   }
 
   @override
-  Future<Map<String, dynamic>> getOrtValueData(String valueId, String dataType) async {
-    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('getOrtValueData', {
-      'valueId': valueId,
-      'dataType': dataType,
-    });
+  Future<Map<String, dynamic>> getOrtValueData(String valueId) async {
+    final result = await methodChannel.invokeMethod<Map<Object?, Object?>>('getOrtValueData', {'valueId': valueId});
     return _convertMapToStringDynamic(result ?? {});
   }
 

--- a/lib/src/flutter_onnxruntime_platform_interface.dart
+++ b/lib/src/flutter_onnxruntime_platform_interface.dart
@@ -113,8 +113,7 @@ abstract class FlutterOnnxruntimePlatform extends PlatformInterface {
   /// Gets the data from an OrtValue
   ///
   /// [valueId] is the ID of the OrtValue to get data from
-  /// [dataType] is the requested data type (e.g., 'float32', 'int32')
-  Future<Map<String, dynamic>> getOrtValueData(String valueId, String dataType) {
+  Future<Map<String, dynamic>> getOrtValueData(String valueId) {
     throw UnimplementedError('getOrtValueData() has not been implemented.');
   }
 

--- a/lib/src/ort_value.dart
+++ b/lib/src/ort_value.dart
@@ -104,6 +104,42 @@ class OrtValue {
     return OrtValue.fromMap(result);
   }
 
+  /// Convert this tensor to a different data type
+  ///
+  /// [targetType] is the target data type to convert to
+  Future<OrtValue> to(OrtDataType targetType) async {
+    final result = await FlutterOnnxruntimePlatform.instance.convertOrtValue(id, targetType.toString().split('.').last);
+    return OrtValue.fromMap(result);
+  }
+
+  /// Move this tensor to a different device
+  ///
+  /// [targetDevice] is the target device to move to
+  Future<OrtValue> toDevice(OrtDevice targetDevice) async {
+    final result = await FlutterOnnxruntimePlatform.instance.moveOrtValueToDevice(
+      id,
+      targetDevice.toString().split('.').last,
+    );
+    return OrtValue.fromMap(result);
+  }
+
+  /// Get the data from this tensor as a list with the native data type
+  ///
+  /// Returns the data in its original type:
+  /// - Float values for float32 and float16 tensors
+  /// - Int values for int32, int64, int16, int8, uint8, uint16, uint32, uint64 tensors
+  /// - Boolean values for bool tensors
+  /// - String values for string tensors
+  Future<List<dynamic>> asList() async {
+    final data = await FlutterOnnxruntimePlatform.instance.getOrtValueData(id);
+    return List<dynamic>.from(data['data']);
+  }
+
+  /// Release native resources associated with this tensor
+  Future<void> dispose() async {
+    await FlutterOnnxruntimePlatform.instance.releaseOrtValue(id);
+  }
+
   /// Converts a regular List to appropriate TypedData based on content
   static dynamic _convertListToTypedData(List data) {
     if (data.isEmpty) {
@@ -150,69 +186,5 @@ class OrtValue {
     }
 
     throw ArgumentError('Unsupported element type: ${firstElement.runtimeType} in list');
-  }
-
-  /// Convert this tensor to a different data type
-  ///
-  /// [targetType] is the target data type to convert to
-  Future<OrtValue> to(OrtDataType targetType) async {
-    final result = await FlutterOnnxruntimePlatform.instance.convertOrtValue(id, targetType.toString().split('.').last);
-    return OrtValue.fromMap(result);
-  }
-
-  /// Move this tensor to a different device
-  ///
-  /// [targetDevice] is the target device to move to
-  Future<OrtValue> toDevice(OrtDevice targetDevice) async {
-    final result = await FlutterOnnxruntimePlatform.instance.moveOrtValueToDevice(
-      id,
-      targetDevice.toString().split('.').last,
-    );
-    return OrtValue.fromMap(result);
-  }
-
-  /// Get the data from this tensor as a Float32List
-  ///
-  /// This method will convert the tensor to float32 if it's not already
-  Future<Float32List> asFloat32List() async {
-    final data = await FlutterOnnxruntimePlatform.instance.getOrtValueData(id, 'float32');
-    return Float32List.fromList(List<double>.from(data['data']));
-  }
-
-  /// Get the data from this tensor as an Int32List
-  ///
-  /// This method will convert the tensor to int32 if it's not already
-  Future<Int32List> asInt32List() async {
-    final data = await FlutterOnnxruntimePlatform.instance.getOrtValueData(id, 'int32');
-    return Int32List.fromList(List<int>.from(data['data']));
-  }
-
-  /// Get the data from this tensor as an Int64List
-  ///
-  /// This method will convert the tensor to int64 if it's not already
-  Future<Int64List> asInt64List() async {
-    final data = await FlutterOnnxruntimePlatform.instance.getOrtValueData(id, 'int64');
-    return Int64List.fromList(List<int>.from(data['data']));
-  }
-
-  /// Get the data from this tensor as a Uint8List
-  ///
-  /// This method will convert the tensor to uint8 if it's not already
-  Future<Uint8List> asUint8List() async {
-    final data = await FlutterOnnxruntimePlatform.instance.getOrtValueData(id, 'uint8');
-    return Uint8List.fromList(List<int>.from(data['data']));
-  }
-
-  /// Get the data from this tensor as a list of booleans
-  ///
-  /// This method will convert the tensor to boolean if it's not already
-  Future<List<bool>> asBoolList() async {
-    final data = await FlutterOnnxruntimePlatform.instance.getOrtValueData(id, 'bool');
-    return List<bool>.from(data['data']);
-  }
-
-  /// Release native resources associated with this tensor
-  Future<void> dispose() async {
-    await FlutterOnnxruntimePlatform.instance.releaseOrtValue(id);
   }
 }

--- a/linux/ort_value.h
+++ b/linux/ort_value.h
@@ -9,6 +9,9 @@
 // Helper function to generate a UUID for OrtValue
 std::string generate_ort_value_uuid();
 
+// Helper function to convert ONNX tensor element data type to string
+std::string get_element_type_name(ONNXTensorElementDataType type);
+
 // Global map to store OrtValue objects - accessible from other files
 extern std::unordered_map<std::string, std::unique_ptr<Ort::Value>> g_ort_values;
 
@@ -41,9 +44,8 @@ char *ort_move_tensor_to_device(const char *value_id,      // ID of the OrtValue
 
 // Get data from an OrtValue
 // Returns a JSON string with data and shape or nullptr on error
-char *ort_get_tensor_data(const char *value_id,  // ID of the OrtValue to get data from
-                          const char *data_type, // Requested data type
-                          char **error_out       // Error message (out parameter)
+char *ort_get_tensor_data(const char *value_id, // ID of the OrtValue to get data from
+                          char **error_out      // Error message (out parameter)
 );
 
 // Release an OrtValue

--- a/macos/Classes/FlutterOnnxruntimePlugin.swift
+++ b/macos/Classes/FlutterOnnxruntimePlugin.swift
@@ -606,9 +606,8 @@ public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
   // swiftlint:disable:next cyclomatic_complexity
   private func handleGetOrtValueData(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     guard let args = call.arguments as? [String: Any],
-          let valueId = args["valueId"] as? String,
-          let dataType = args["dataType"] as? String else {
-      result(FlutterError(code: "INVALID_ARGS", message: "Missing required arguments", details: nil))
+          let valueId = args["valueId"] as? String else {
+      result(FlutterError(code: "INVALID_ARGS", message: "Missing valueId", details: nil))
       return
     }
 
@@ -621,91 +620,67 @@ public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
       // Get tensor information
       let tensorInfo = try tensor.tensorTypeAndShapeInfo()
       let shape = tensorInfo.shape.map { Int(truncating: $0) }
-
-      // Calculate element count
       let elementCount = shape.reduce(1, *)
-
-      // Extract data according to requested type
       var data: Any
+      let dataType = _getDataTypeName(from: tensorInfo.elementType)
 
-      // Extract data based on the tensor's type and requested type
-      switch dataType {
-      case "float32":
-        if tensorInfo.elementType == .float {
-          // Get float data directly
-          let dataPtr = try tensor.tensorData()
-          let floatPtr = dataPtr.bytes.bindMemory(to: Float.self, capacity: elementCount)
-          let floatBuffer = UnsafeBufferPointer(start: floatPtr, count: elementCount)
-          data = Array(floatBuffer)
-        } else {
-          // For other types, we need to convert to float
-          // This is a simplified implementation
-          result(FlutterError(code: "CONVERSION_ERROR",
-                             message: "Conversion from \(tensorInfo.elementType) to float32 not implemented",
-                             details: nil))
-          return
-        }
+      // Extract data based on the tensor's native type
+      switch tensorInfo.elementType {
+      case .float:
+        // Get float data directly
+        let dataPtr = try tensor.tensorData()
+        let floatPtr = dataPtr.bytes.bindMemory(to: Float.self, capacity: elementCount)
+        let floatBuffer = UnsafeBufferPointer(start: floatPtr, count: elementCount)
+        data = Array(floatBuffer)
 
-      case "int32":
-        if tensorInfo.elementType == .int32 {
-          // Get int32 data directly
-          let dataPtr = try tensor.tensorData()
-          let intPtr = dataPtr.bytes.bindMemory(to: Int32.self, capacity: elementCount)
-          let intBuffer = UnsafeBufferPointer(start: intPtr, count: elementCount)
-          data = Array(intBuffer)
-        } else {
-          // For other types, we need to convert to int32
-          result(FlutterError(code: "CONVERSION_ERROR", message: "Conversion from \(tensorInfo.elementType) to int32 not implemented", details: nil))
-          return
-        }
+      case .int32:
+        // Get int32 data directly
+        let dataPtr = try tensor.tensorData()
+        let intPtr = dataPtr.bytes.bindMemory(to: Int32.self, capacity: elementCount)
+        let intBuffer = UnsafeBufferPointer(start: intPtr, count: elementCount)
+        data = Array(intBuffer)
 
-      case "int64":
-        if tensorInfo.elementType == .int64 {
-          // Get int64 data directly
-          let dataPtr = try tensor.tensorData()
-          let int64Ptr = dataPtr.bytes.bindMemory(to: Int64.self, capacity: elementCount)
-          let int64Buffer = UnsafeBufferPointer(start: int64Ptr, count: elementCount)
-          data = Array(int64Buffer)
-        } else {
-          // For other types, we need to convert to int64
-          result(FlutterError(code: "CONVERSION_ERROR", message: "Conversion from \(tensorInfo.elementType) to int64 not implemented", details: nil))
-          return
-        }
+      case .int64:
+        // Get int64 data directly
+        let dataPtr = try tensor.tensorData()
+        let int64Ptr = dataPtr.bytes.bindMemory(to: Int64.self, capacity: elementCount)
+        let int64Buffer = UnsafeBufferPointer(start: int64Ptr, count: elementCount)
+        data = Array(int64Buffer)
 
-      case "uint8":
-        if tensorInfo.elementType == .uInt8 {
-          // Get uint8 data directly
-          let dataPtr = try tensor.tensorData()
-          let uint8Ptr = dataPtr.bytes.bindMemory(to: UInt8.self, capacity: elementCount)
-          let uint8Buffer = UnsafeBufferPointer(start: uint8Ptr, count: elementCount)
-          data = Array(uint8Buffer)
-        } else {
-          result(FlutterError(code: "CONVERSION_ERROR", message: "Conversion from \(tensorInfo.elementType) to uint8 not implemented", details: nil))
-          return
-        }
+      case .uInt8:
+        // Get uint8 data directly
+        let dataPtr = try tensor.tensorData()
+        let uint8Ptr = dataPtr.bytes.bindMemory(to: UInt8.self, capacity: elementCount)
+        let uint8Buffer = UnsafeBufferPointer(start: uint8Ptr, count: elementCount)
+        data = Array(uint8Buffer)
 
-      case "bool":
-        if tensorInfo.elementType == .uInt8 {
-          // Get bool data as uint8 (0 = false, non-zero = true)
-          let dataPtr = try tensor.tensorData()
-          let uint8Ptr = dataPtr.bytes.bindMemory(to: UInt8.self, capacity: elementCount)
-          let uint8Buffer = UnsafeBufferPointer(start: uint8Ptr, count: elementCount)
-          // Convert UInt8 to Bool
-          data = uint8Buffer.map { $0 != 0 }
-        } else {
-          result(FlutterError(code: "CONVERSION_ERROR", message: "Conversion from \(tensorInfo.elementType) to bool not implemented", details: nil))
-          return
-        }
+      case .int8:
+        // Get int8 data directly
+        let dataPtr = try tensor.tensorData()
+        let int8Ptr = dataPtr.bytes.bindMemory(to: Int8.self, capacity: elementCount)
+        let int8Buffer = UnsafeBufferPointer(start: int8Ptr, count: elementCount)
+        data = Array(int8Buffer)
+
+      case .string:
+        // For string tensors
+        let dataPtr = try tensor.tensorData()
+        let stringPtr = dataPtr.bytes.bindMemory(to: String.self, capacity: elementCount)
+        let stringBuffer = UnsafeBufferPointer(start: stringPtr, count: elementCount)
+        data = Array(stringBuffer)
 
       default:
-        result(FlutterError(code: "UNSUPPORTED_TYPE", message: "Unsupported data type: \(dataType)", details: nil))
-        return
+        // Try to extract as float for unsupported types
+        let dataPtr = try tensor.tensorData()
+        let floatPtr = dataPtr.bytes.bindMemory(to: Float.self, capacity: elementCount)
+        let floatBuffer = UnsafeBufferPointer(start: floatPtr, count: elementCount)
+        data = Array(floatBuffer)
       }
 
-      // Return data with shape
+      // Return data with shape and dataType
       let resultMap: [String: Any] = [
         "data": data,
-        "shape": shape
+        "shape": shape,
+        "dataType": dataType
       ]
 
       result(resultMap)

--- a/test/unit/flutter_onnxruntime_test.dart
+++ b/test/unit/flutter_onnxruntime_test.dart
@@ -88,7 +88,10 @@ class MockFlutterOnnxruntimePlatform with MockPlatformInterfaceMixin implements 
   Future<Map<String, dynamic>> createOrtValue(String sourceType, data, List<int> shape) => Future.value({});
 
   @override
-  Future<Map<String, dynamic>> getOrtValueData(String valueId, String dataType) => Future.value({});
+  Future<Map<String, dynamic>> getOrtValueData(String valueId) => Future.value({
+    'data': [1.0, 2.0, 3.0, 4.0],
+    'shape': [2, 2],
+  });
 
   @override
   Future<Map<String, dynamic>> moveOrtValueToDevice(String valueId, String targetDevice) => Future.value({});

--- a/test/unit/ort_session_test.dart
+++ b/test/unit/ort_session_test.dart
@@ -109,7 +109,10 @@ class MockFlutterOnnxruntimePlatform with MockPlatformInterfaceMixin implements 
   Future<Map<String, dynamic>> convertOrtValue(String valueId, String targetType) => Future.value({});
 
   @override
-  Future<Map<String, dynamic>> getOrtValueData(String valueId, String dataType) => Future.value({});
+  Future<Map<String, dynamic>> getOrtValueData(String valueId) => Future.value({
+    'data': [1.0, 2.0, 3.0, 4.0],
+    'shape': [2, 2],
+  });
 
   @override
   Future<Map<String, dynamic>> moveOrtValueToDevice(String valueId, String targetDevice) => Future.value({});

--- a/test/unit/ort_value_session_integration_test.dart
+++ b/test/unit/ort_value_session_integration_test.dart
@@ -110,7 +110,7 @@ class MockFlutterOnnxruntimePlatform with MockPlatformInterfaceMixin implements 
   }
 
   @override
-  Future<Map<String, dynamic>> getOrtValueData(String valueId, String dataType) {
+  Future<Map<String, dynamic>> getOrtValueData(String valueId) {
     return Future.value({
       'data': [1.0, 2.0, 3.0, 4.0],
       'shape': [2, 2],

--- a/test/unit/ort_value_test.dart
+++ b/test/unit/ort_value_test.dart
@@ -13,7 +13,6 @@ class MockFlutterOnnxruntimePlatform with MockPlatformInterfaceMixin implements 
   String? lastValueIdForConversion;
   String? lastValueIdForRelease;
   String? lastValueIdForData;
-  String? lastRequestedDataType;
 
   @override
   Future<String?> getPlatformVersion() => Future.value('42');
@@ -73,44 +72,15 @@ class MockFlutterOnnxruntimePlatform with MockPlatformInterfaceMixin implements 
   }
 
   @override
-  Future<Map<String, dynamic>> getOrtValueData(String valueId, String dataType) {
+  Future<Map<String, dynamic>> getOrtValueData(String valueId) {
     // Track the call
     lastValueIdForData = valueId;
-    lastRequestedDataType = dataType;
 
-    // Return different data based on the requested type
-    switch (dataType) {
-      case 'float32':
-        return Future.value({
-          'data': [1.0, 2.0, 3.0, 4.0],
-          'shape': [2, 2],
-        });
-      case 'int32':
-        return Future.value({
-          'data': [1, 2, 3, 4],
-          'shape': [2, 2],
-        });
-      case 'int64':
-        return Future.value({
-          'data': [1, 2, 3, 4],
-          'shape': [2, 2],
-        });
-      case 'uint8':
-        return Future.value({
-          'data': [1, 2, 3, 4],
-          'shape': [2, 2],
-        });
-      case 'bool':
-        return Future.value({
-          'data': [true, false, true, false],
-          'shape': [2, 2],
-        });
-      default:
-        return Future.value({
-          'data': [],
-          'shape': [0],
-        });
-    }
+    // Return data in a format that works for all types
+    return Future.value({
+      'data': [1.0, 2.0, 3.0, 4.0],
+      'shape': [2, 2],
+    });
   }
 
   @override
@@ -353,58 +323,21 @@ void main() {
   });
 
   group('OrtValue data extraction', () {
-    test('asFloat32List() should return Float32List data', () async {
+    test('asList() should return data in native format', () async {
       // Create an OrtValue
       final tensor = await OrtValue.fromList(Float32List.fromList([1.0, 2.0, 3.0, 4.0]), [2, 2]);
 
-      // Get data as Float32List
-      final data = await tensor.asFloat32List();
+      // Get data in native format
+      final data = await tensor.asList();
 
       // Verify the call
       expect(mockPlatform.lastValueIdForData, tensor.id);
-      expect(mockPlatform.lastRequestedDataType, 'float32');
 
       // Verify the returned data
-      expect(data, isA<Float32List>());
+      expect(data, isA<List>());
       expect(data.length, 4);
       expect(data[0], 1.0);
       expect(data[3], 4.0);
-    });
-
-    test('asInt32List() should return Int32List data', () async {
-      // Create an OrtValue
-      final tensor = await OrtValue.fromList(Int32List.fromList([1, 2, 3, 4]), [2, 2]);
-
-      // Get data as Int32List
-      final data = await tensor.asInt32List();
-
-      // Verify the call
-      expect(mockPlatform.lastValueIdForData, tensor.id);
-      expect(mockPlatform.lastRequestedDataType, 'int32');
-
-      // Verify the returned data
-      expect(data, isA<Int32List>());
-      expect(data.length, 4);
-      expect(data[0], 1);
-      expect(data[3], 4);
-    });
-
-    test('asBoolList() should return bool list data', () async {
-      // Create an OrtValue
-      final tensor = await OrtValue.fromList([true, false, true, false], [2, 2]);
-
-      // Get data as bool list
-      final data = await tensor.asBoolList();
-
-      // Verify the call
-      expect(mockPlatform.lastValueIdForData, tensor.id);
-      expect(mockPlatform.lastRequestedDataType, 'bool');
-
-      // Verify the returned data
-      expect(data, isA<List<bool>>());
-      expect(data.length, 4);
-      expect(data[0], true);
-      expect(data[1], false);
     });
   });
 


### PR DESCRIPTION
Context:
* The current getOrtValue provides options to return in a specific data type, which is likely to include an implicit conversion and cause more overhead in processing

Changes:
* Remove the dataType in getOrtValue()
* Return native format of the OrtValue as a list