### PR TITLE
Return multi-dimensional list for tensor data

### DIFF
--- a/doc/api_usage.md
+++ b/doc/api_usage.md
@@ -149,9 +149,15 @@ final float16Tensor = await float32Tensor.to(OrtDataType.float16);
 ### Accessing Tensor Data
 
 ```dart
-// Get data as a List
+// Get data as a multi-dimensional List following the tensor's shape
 final tensorData = await float32Tensor.asList();
-print('Tensor data: $tensorData');
+print('Tensor data (shaped): $tensorData');
+// For a tensor with shape [2, 2], this prints: [[1.0, 2.0], [3.0, 4.0]]
+
+// Get data as a flattened 1D List
+final flattenedData = await float32Tensor.asFlattenedList();
+print('Tensor data (flattened): $flattenedData');
+// This prints: [1.0, 2.0, 3.0, 4.0]
 ```
 
 ### Important Memory Management

--- a/example/integration_test/all_tests.dart
+++ b/example/integration_test/all_tests.dart
@@ -54,7 +54,7 @@ void main() {
         expect(tensor.dataType, OrtDataType.float32);
         expect(tensor.shape, shape);
 
-        final retrievedData = await tensor.asList();
+        final retrievedData = await tensor.asFlattenedList();
         expect(retrievedData.length, 4);
         for (int i = 0; i < inputData.length; i++) {
           expect(retrievedData[i], closeTo(inputData[i], 1e-5));
@@ -71,7 +71,7 @@ void main() {
         expect(tensor.dataType, OrtDataType.int32);
         expect(tensor.shape, shape);
 
-        final retrievedData = await tensor.asList();
+        final retrievedData = await tensor.asFlattenedList();
         expect(retrievedData.length, 6);
         for (int i = 0; i < inputData.length; i++) {
           expect(retrievedData[i], inputData[i]);
@@ -88,7 +88,7 @@ void main() {
         expect(tensor.dataType, OrtDataType.uint8);
         expect(tensor.shape, shape);
 
-        final retrievedData = await tensor.asList();
+        final retrievedData = await tensor.asFlattenedList();
         expect(retrievedData.length, 4);
         for (int i = 0; i < inputData.length; i++) {
           expect(retrievedData[i], inputData[i]);
@@ -105,7 +105,7 @@ void main() {
         expect(tensor.dataType, OrtDataType.bool);
         expect(tensor.shape, shape);
 
-        final retrievedData = await tensor.asList();
+        final retrievedData = await tensor.asFlattenedList();
         expect(retrievedData.length, 4);
         for (int i = 0; i < inputData.length; i++) {
           final retrievedBoolValue = retrievedData[i] == 1;
@@ -123,7 +123,7 @@ void main() {
         expect(tensor.dataType, OrtDataType.float32);
         expect(tensor.shape, shape);
 
-        final retrievedData = await tensor.asList();
+        final retrievedData = await tensor.asFlattenedList();
         expect(retrievedData.length, 4);
         for (int i = 0; i < inputData.length; i++) {
           expect(retrievedData[i], closeTo(inputData[i], 1e-5));
@@ -140,7 +140,7 @@ void main() {
         expect(tensor.dataType, OrtDataType.int32);
         expect(tensor.shape, shape);
 
-        final retrievedData = await tensor.asList();
+        final retrievedData = await tensor.asFlattenedList();
         expect(retrievedData.length, 4);
         for (int i = 0; i < inputData.length; i++) {
           expect(retrievedData[i], inputData[i]);
@@ -242,7 +242,7 @@ void main() {
       });
     });
 
-    group('Tensor Shape Tests', () {
+    group('Tensor Creation With Shape Tests', () {
       testWidgets('Tensor size and target shape mismatch', (WidgetTester tester) async {
         final inputData = [1.1, 2.2, 3.3, 4.4, 5.5];
         final shape = [2, 2];
@@ -263,7 +263,8 @@ void main() {
         expect(tensor.shape, shape);
 
         final retrievedData = await tensor.asList();
-        expect(retrievedData.length, 4);
+        expect(retrievedData.length, shape[0]);
+        expect(retrievedData[0].length, shape[1]);
       });
 
       testWidgets('Negative value in shape test', (WidgetTester tester) async {
@@ -272,6 +273,27 @@ void main() {
 
         // expect to throw an ArgumentError
         expect(() async => await OrtValue.fromList(inputData, shape), throwsA(isA<ArgumentError>()));
+      });
+    });
+
+    group('Tensor Data Extraction Shape Test', () {
+      testWidgets('Test 2x2 tensor data extraction', (WidgetTester tester) async {
+        final inputData = [1.1, 2.2, 3.3, 4.4];
+        final shape = [2, 2];
+        final tensor = await OrtValue.fromList(inputData, shape);
+
+        final tensorData = await tensor.asList();
+        final tensorData1d = await tensor.asFlattenedList();
+        expect(tensorData.length, shape[0]);
+        var id = 0;
+        for (final sublist in tensorData) {
+          expect(sublist.length, shape[1]);
+          for (final num in sublist) {
+            expect(num, closeTo(inputData[id], 1e-5));
+            expect(tensorData1d[id], closeTo(inputData[id], 1e-5));
+            id++;
+          }
+        }
       });
     });
 
@@ -513,7 +535,7 @@ void main() {
         await session.close();
       });
 
-      testWidgets('FP32 model inference test', (WidgetTester tester) async {
+      testWidgets('Inference test with single batch', (WidgetTester tester) async {
         inputs = {
           'A': await OrtValue.fromList([1.0, 1.0, 1.0, 1.0, 1.0, 1.0], [1, 2, 3]),
           'B': await OrtValue.fromList([2.0, 2.0, 2.0, 2.0, 2.0, 2.0], [1, 3, 2]),
@@ -523,8 +545,10 @@ void main() {
         expect(output!.dataType, OrtDataType.float32);
         expect(output.shape, [1, 2, 3]);
         final outputData = await output.asList();
-        expect(outputData.length, 6);
-        expect(outputData.every((e) => e == 1.5), true);
+        expect(outputData.length, output.shape[0]);
+        expect(outputData[0].length, output.shape[1]);
+        expect(outputData[0][0].length, output.shape[2]);
+        expect(outputData.expand((e0) => e0).expand((e) => e).every((element) => element == 1.5), true);
 
         // clean up
         for (var input in inputs.values) {
@@ -533,7 +557,7 @@ void main() {
         await output.dispose();
       });
 
-      testWidgets('FP32 model inference test with multi-batch', (WidgetTester tester) async {
+      testWidgets('Inference test with multi-batch', (WidgetTester tester) async {
         inputs = {
           'A': await OrtValue.fromList(
             [
@@ -555,8 +579,14 @@ void main() {
         expect(output!.dataType, OrtDataType.float32);
         expect(output.shape, [2, 2, 3]);
         final outputData = await output.asList();
-        expect(outputData.length, 12);
-        expect(outputData.every((e) => e == 1.5), true);
+        final outputData1d = await output.asFlattenedList();
+        // check values of 1d list
+        expect(outputData1d.length, 12);
+        expect(outputData1d.every((e) => e == 1.5), true);
+        // check shape of multi-dim list
+        expect(outputData.length, output.shape[0]);
+        expect(outputData[0].length, output.shape[1]);
+        expect(outputData[0][0].length, output.shape[2]);
 
         // clean up
         for (var input in inputs.values) {
@@ -630,7 +660,7 @@ void main() {
         expect(output!.dataType, OrtDataType.int32);
         expect(output.shape, [1, 2, 3]);
 
-        final outputData = await output.asList();
+        final outputData = await output.asFlattenedList();
         expect(outputData.length, 6);
         expect(outputData.every((e) => e == 1), true); // 1 + 2 = 3, 3 * 0.5 = 1.5 -> 1
 
@@ -670,8 +700,12 @@ void main() {
           expect(output.shape, [1, 2, 3]);
 
           final outputData = await output.asList();
-          expect(outputData.length, 6);
-          expect(outputData.every((e) => e == 1.5), true);
+          // check shape
+          expect(outputData.length, output.shape[0]);
+          expect(outputData[0].length, output.shape[1]);
+          expect(outputData[0][0].length, output.shape[2]);
+          // check value
+          expect(outputData.expand((e0) => e0).expand((e) => e).every((element) => element == 1.5), true);
 
           // clean up
           await tensorA.dispose();

--- a/example/integration_test/all_tests.dart
+++ b/example/integration_test/all_tests.dart
@@ -277,22 +277,37 @@ void main() {
     });
 
     group('Tensor Data Extraction Shape Test', () {
-      testWidgets('Test 2x2 tensor data extraction', (WidgetTester tester) async {
+      testWidgets('Test 2x2 tensor data as multi-dim list', (WidgetTester tester) async {
         final inputData = [1.1, 2.2, 3.3, 4.4];
         final shape = [2, 2];
         final tensor = await OrtValue.fromList(inputData, shape);
 
         final tensorData = await tensor.asList();
-        final tensorData1d = await tensor.asFlattenedList();
+        expect(tensorData, isA<List>());
+        expect(tensorData[0], isA<List>());
+
         expect(tensorData.length, shape[0]);
         var id = 0;
         for (final sublist in tensorData) {
           expect(sublist.length, shape[1]);
           for (final num in sublist) {
             expect(num, closeTo(inputData[id], 1e-5));
-            expect(tensorData1d[id], closeTo(inputData[id], 1e-5));
             id++;
           }
+        }
+      });
+
+      testWidgets('Test 2x2 tensor data as flat list', (WidgetTester tester) async {
+        final inputData = [1.1, 2.2, 3.3, 4.4];
+        final shape = [2, 2];
+        final tensor = await OrtValue.fromList(inputData, shape);
+
+        final tensorData1d = await tensor.asFlattenedList();
+        expect(tensorData1d, isA<List>());
+        expect(tensorData1d.length, 4);
+
+        for (int i = 0; i < inputData.length; i++) {
+          expect(tensorData1d[i], closeTo(inputData[i], 1e-5));
         }
       });
     });

--- a/lib/flutter_onnxruntime.dart
+++ b/lib/flutter_onnxruntime.dart
@@ -8,4 +8,5 @@ library;
 
 export 'src/onnxruntime.dart' show OnnxRuntime;
 export 'src/ort_session.dart' show OrtSession, OrtSessionOptions, OrtRunOptions;
+export 'src/ort_model_metadata.dart' show OrtModelMetadata;
 export 'src/ort_value.dart' show OrtValue, OrtDataType;

--- a/test/unit/flutter_onnxruntime_test.dart
+++ b/test/unit/flutter_onnxruntime_test.dart
@@ -8,7 +8,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_onnxruntime/flutter_onnxruntime.dart';
 import 'package:flutter_onnxruntime/src/flutter_onnxruntime_platform_interface.dart';
 import 'package:flutter_onnxruntime/src/flutter_onnxruntime_method_channel.dart';
-import 'package:flutter_onnxruntime/src/ort_model_metadata.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 class MockFlutterOnnxruntimePlatform with MockPlatformInterfaceMixin implements FlutterOnnxruntimePlatform {


### PR DESCRIPTION
* `OrtValue.asList()` change to returning multi-dimensional lists instead of 1D lists
* Use `OrtValue.asFlattenedList()` to return a flat list