### PR TITLE
Standardize the Provider names across platforms

### DIFF
--- a/android/src/main/kotlin/com/masicai/flutteronnxruntime/FlutterOnnxruntimePlugin.kt
+++ b/android/src/main/kotlin/com/masicai/flutteronnxruntime/FlutterOnnxruntimePlugin.kt
@@ -159,6 +159,28 @@ class FlutterOnnxruntimePlugin : FlutterPlugin, MethodCallHandler {
         }
     }
 
+    /**
+     * Map provider name to enum name
+     */
+    private fun mapProviderNameToEnumName(providerName: String): String {
+        return when (providerName) {
+            "ACL" -> "ACL"
+            "ARM_NN" -> "ARM_NN"
+            "CORE_ML" -> "CORE_ML"
+            "CPU" -> "CPU"
+            "CUDA" -> "CUDA"
+            "DIRECT_ML" -> "DIRECT_ML"
+            "DNNL" -> "DNNL"
+            "NNAPI" -> "NNAPI"
+            "OPEN_VINO" -> "OPEN_VINO"
+            "QNN" -> "QNN"
+            "ROCM" -> "ROCM"
+            "TENSOR_RT" -> "TENSOR_RT"
+            "XNNPACK" -> "XNNPACK"
+            else -> providerName
+        }
+    }
+
     override fun onAttachedToEngine(
         @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding,
     ) {
@@ -295,7 +317,7 @@ class FlutterOnnxruntimePlugin : FlutterPlugin, MethodCallHandler {
             }
             "getAvailableProviders" -> {
                 val providers = OrtEnvironment.getAvailableProviders()
-                val providerList = providers.map { it.toString() }.toList()
+                val providerList = providers.map { mapProviderNameToEnumName(it.toString()) }.toList()
                 result.success(providerList)
             }
             "runInference" -> {

--- a/example/integration_test/all_tests.dart
+++ b/example/integration_test/all_tests.dart
@@ -388,6 +388,34 @@ void main() {
         fail('Failed to get available providers: $e');
       }
     });
+
+    testWidgets('Create session with CPU provider', (WidgetTester tester) async {
+      final session = await onnxRuntime.createSessionFromAsset(
+        'assets/models/addition_model.ort',
+        options: OrtSessionOptions(providers: [OrtProvider.CPU]),
+      );
+      expect(session, isNotNull);
+      await session.close();
+    });
+
+    testWidgets('Create session with not available provider', (WidgetTester tester) async {
+      // set a negative provider
+      // we assume that CORE_ML is never available on Android and Linux
+      // and XNNPACK is never available on iOS and MacOS
+      OrtProvider negativeProvider = OrtProvider.CORE_ML;
+      if (Platform.isIOS || Platform.isMacOS) {
+        negativeProvider = OrtProvider.XNNPACK;
+      }
+      try {
+        await onnxRuntime.createSessionFromAsset(
+          'assets/models/addition_model.ort',
+          options: OrtSessionOptions(providers: [negativeProvider]),
+        );
+        fail('Session should not be created');
+      } catch (e) {
+        expect(e, isA<PlatformException>());
+      }
+    });
   });
 
   group('Session Info Tests', () {

--- a/lib/flutter_onnxruntime.dart
+++ b/lib/flutter_onnxruntime.dart
@@ -10,3 +10,4 @@ export 'src/onnxruntime.dart' show OnnxRuntime;
 export 'src/ort_session.dart' show OrtSession, OrtSessionOptions, OrtRunOptions;
 export 'src/ort_model_metadata.dart' show OrtModelMetadata;
 export 'src/ort_value.dart' show OrtValue, OrtDataType;
+export 'src/ort_provider.dart' show OrtProvider;

--- a/lib/src/onnxruntime.dart
+++ b/lib/src/onnxruntime.dart
@@ -4,11 +4,14 @@
 // This source code is licensed under the license found in the
 // LICENSE file in the root directory of this source tree.
 
+// ignore_for_file: constant_identifier_names
+
 import 'dart:io';
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 
 import 'package:flutter_onnxruntime/src/flutter_onnxruntime_platform_interface.dart';
+import 'package:flutter_onnxruntime/src/ort_provider.dart';
 import 'package:flutter_onnxruntime/src/ort_session.dart';
 
 class OnnxRuntime {
@@ -49,7 +52,16 @@ class OnnxRuntime {
   }
 
   /// Get the available providers
-  Future<List<String>> getAvailableProviders() async {
-    return FlutterOnnxruntimePlatform.instance.getAvailableProviders();
+  ///
+  /// Returns a list of the available providers
+  Future<List<OrtProvider>> getAvailableProviders() async {
+    final providers = await FlutterOnnxruntimePlatform.instance.getAvailableProviders();
+    return providers.map((p) {
+      final provider = OrtProvider.values.firstWhere(
+        (e) => e.name == p,
+        orElse: () => throw ArgumentError('Provider $p is not a valid OrtProvider.'),
+      );
+      return provider;
+    }).toList();
   }
 }

--- a/lib/src/ort_provider.dart
+++ b/lib/src/ort_provider.dart
@@ -1,0 +1,13 @@
+// Copyright (c) MASIC AI
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+// ignore_for_file: constant_identifier_names
+
+/// The execution provider to use for the ONNX Runtime session
+///
+/// Following the name of the execution provider in the ONNX Runtime Java API at:
+/// https://onnxruntime.ai/docs/api/java/ai/onnxruntime/OrtProvider.html
+enum OrtProvider { ACL, ARM_NN, CORE_ML, CPU, CUDA, DIRECT_ML, DNNL, NNAPI, OPEN_VINO, QNN, ROCM, TENSOR_RT, XNNPACK }

--- a/lib/src/ort_session.dart
+++ b/lib/src/ort_session.dart
@@ -6,6 +6,7 @@
 
 import 'package:flutter_onnxruntime/src/flutter_onnxruntime_platform_interface.dart';
 import 'package:flutter_onnxruntime/src/ort_model_metadata.dart';
+import 'package:flutter_onnxruntime/src/ort_provider.dart';
 import 'package:flutter_onnxruntime/src/ort_value.dart';
 
 class OrtSession {
@@ -93,8 +94,8 @@ class OrtSessionOptions {
   // Sets the number of threads used to parallelize the execution of the graph (across nodes)
   final int? interOpNumThreads;
   // set a list of providers, if one provider is not available, ORT will fallback to the next provider in the list
-  // for example: ["CUDA", "CPU"]
-  final List<String>? providers;
+  // for example: [OrtProvider.CUDA, OrtProvider.CPU]
+  final List<OrtProvider>? providers;
   // arena allocator for memory management, default is true
   final bool? useArena;
   // set the device id for the session, default is 0
@@ -106,7 +107,7 @@ class OrtSessionOptions {
     return {
       if (intraOpNumThreads != null) 'intraOpNumThreads': intraOpNumThreads,
       if (interOpNumThreads != null) 'interOpNumThreads': interOpNumThreads,
-      if (providers != null && providers!.isNotEmpty) 'providers': providers,
+      if (providers != null && providers!.isNotEmpty) 'providers': providers!.map((p) => p.name).toList(),
       if (useArena != null) 'useArena': useArena,
       if (deviceId != null) 'deviceId': deviceId,
     };

--- a/test/unit/flutter_onnxruntime_test.dart
+++ b/test/unit/flutter_onnxruntime_test.dart
@@ -162,8 +162,8 @@ void main() {
       final providers = await onnxRuntime.getAvailableProviders();
 
       expect(providers, isNotNull);
-      expect(providers, isA<List<String>>());
-      expect(providers, contains('CPU'));
+      expect(providers, isA<List<OrtProvider>>());
+      expect(providers, contains(OrtProvider.CPU));
     });
   });
 
@@ -290,12 +290,17 @@ void main() {
 
   group('Options classes', () {
     test('OrtSessionOptions toMap converts options to map correctly', () {
-      final options = OrtSessionOptions(intraOpNumThreads: 4, interOpNumThreads: 2);
+      final options = OrtSessionOptions(
+        intraOpNumThreads: 4,
+        interOpNumThreads: 2,
+        providers: [OrtProvider.CUDA, OrtProvider.CPU],
+      );
 
       final map = options.toMap();
 
       expect(map['intraOpNumThreads'], 4);
       expect(map['interOpNumThreads'], 2);
+      expect(map['providers'], ['CUDA', 'CPU']);
     });
 
     test('OrtRunOptions toMap converts options to map correctly', () {

--- a/test/unit/ort_session_test.dart
+++ b/test/unit/ort_session_test.dart
@@ -526,7 +526,7 @@ void main() {
       final options = OrtSessionOptions(
         intraOpNumThreads: 2,
         interOpNumThreads: 4,
-        providers: ['CUDA', 'CPU'],
+        providers: [OrtProvider.CUDA, OrtProvider.CPU],
         useArena: true,
         deviceId: 0,
       );
@@ -541,7 +541,7 @@ void main() {
     });
 
     test('constructs with partial options and produces correct map', () {
-      final options = OrtSessionOptions(intraOpNumThreads: 2, providers: ['CUDA']);
+      final options = OrtSessionOptions(intraOpNumThreads: 2, providers: [OrtProvider.CUDA]);
 
       final map = options.toMap();
 
@@ -566,7 +566,7 @@ void main() {
       final optionsMock = SessionOptionsMock();
       FlutterOnnxruntimePlatform.instance = optionsMock;
 
-      final options = OrtSessionOptions(providers: ['CUDA', 'CPU'], deviceId: 1);
+      final options = OrtSessionOptions(providers: [OrtProvider.CUDA, OrtProvider.CPU], deviceId: 1);
 
       final onnxRuntime = OnnxRuntime();
       await onnxRuntime.createSession('test_model.onnx', options: options);

--- a/test/unit/ort_value_session_integration_test.dart
+++ b/test/unit/ort_value_session_integration_test.dart
@@ -149,7 +149,7 @@ class ConversionTrackingMock extends MockFlutterOnnxruntimePlatform {
 
 class ProviderOptionsMock extends MockFlutterOnnxruntimePlatform {
   @override
-  Future<List<String>> getAvailableProviders() => Future.value(['CUDA', 'CPU', 'CoreML']);
+  Future<List<String>> getAvailableProviders() => Future.value(['CUDA', 'CPU', 'CORE_ML']);
 
   @override
   Future<Map<String, dynamic>> createSession(String modelPath, {Map<String, dynamic>? sessionOptions}) {
@@ -334,11 +334,11 @@ void main() {
       final availableProviders = await onnxRuntime.getAvailableProviders();
 
       // Verify we get our expected providers
-      expect(availableProviders, containsAll(['CUDA', 'CPU', 'CoreML']));
+      expect(availableProviders, containsAll([OrtProvider.CUDA, OrtProvider.CPU, OrtProvider.CORE_ML]));
 
       // Create session with preferred providers
       final options = OrtSessionOptions(
-        providers: ['CUDA', 'CPU'], // Prioritize CUDA, fallback to CPU
+        providers: [OrtProvider.CUDA, OrtProvider.CPU], // Prioritize CUDA, fallback to CPU
         deviceId: 0,
       );
 


### PR DESCRIPTION
The ONNX Runtime API of `getAvailableProviders()` returns different names for the same provider in different platforms. For example, CPU provider comes with the name "CPU" in Kotlin but being "CPUExecutionProvider" in C++.

In the current approach, users must call getAvailableProviders() to get the correct name. To make the provider name consistent, we use an enum following the provider names in the [Java ONNX Runtime API](https://onnxruntime.ai/docs/api/java/ai/onnxruntime/OrtProvider.html).

Changes:
* Create OrtProvider enum to unify provider names
* Add integration tests
* Adjust current unit tests
