### PR TITLE
Upgrade Kotlin version

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group = "com.masicai.flutteronnxruntime"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    ext.kotlin_version = "1.8.22"
+    ext.kotlin_version = "2.1.0"
     repositories {
         google()
         mavenCentral()

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -13,6 +13,12 @@ Common issues and their solutions.
     ```bash
     echo "-keep class ai.onnxruntime.** { *; }" > android/app/proguard-rules.pro
     ```
+* `...Module was compiled with an incompatible version of Kotlin. The binary version of its metadata is 2.1.0, expected version is 1.8.0`: update your Kotlin version to 2.1.0 in `android/settings.gradle.kts`:
+    ```kotlin
+    plugins {
+        id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    }
+    ```
 
 ## iOS
 * Target minimum version: iOS 16

--- a/example/android/settings.gradle.kts
+++ b/example/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include(":app")


### PR DESCRIPTION
Upgrade the Kotlin version from `1.8.22` to `2.1.0` to avoid warnings from the latest Flutter release.