### PR TITLE
Use BackgroundTaskQueue to avoid UI thread blocking during inference

### DIFF
--- a/android/src/main/kotlin/com/masicai/flutteronnxruntime/FlutterOnnxruntimePlugin.kt
+++ b/android/src/main/kotlin/com/masicai/flutteronnxruntime/FlutterOnnxruntimePlugin.kt
@@ -185,7 +185,12 @@ class FlutterOnnxruntimePlugin : FlutterPlugin, MethodCallHandler {
     override fun onAttachedToEngine(
         @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding,
     ) {
-        channel = MethodChannel(flutterPluginBinding.binaryMessenger, "flutter_onnxruntime")
+        val taskQueue = flutterPluginBinding.binaryMessenger.makeBackgroundTaskQueue()
+        channel = MethodChannel(
+            flutterPluginBinding.binaryMessenger,
+            "flutter_onnxruntime",
+            io.flutter.plugin.common.StandardMethodCodec.INSTANCE,
+            taskQueue)
         channel.setMethodCallHandler(this)
         ortEnvironment = OrtEnvironment.getEnvironment()
     }

--- a/android/src/main/kotlin/com/masicai/flutteronnxruntime/FlutterOnnxruntimePlugin.kt
+++ b/android/src/main/kotlin/com/masicai/flutteronnxruntime/FlutterOnnxruntimePlugin.kt
@@ -186,11 +186,13 @@ class FlutterOnnxruntimePlugin : FlutterPlugin, MethodCallHandler {
         @NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding,
     ) {
         val taskQueue = flutterPluginBinding.binaryMessenger.makeBackgroundTaskQueue()
-        channel = MethodChannel(
-            flutterPluginBinding.binaryMessenger,
-            "flutter_onnxruntime",
-            io.flutter.plugin.common.StandardMethodCodec.INSTANCE,
-            taskQueue)
+        channel =
+            MethodChannel(
+                flutterPluginBinding.binaryMessenger,
+                "flutter_onnxruntime",
+                io.flutter.plugin.common.StandardMethodCodec.INSTANCE,
+                taskQueue,
+            )
         channel.setMethodCallHandler(this)
         ortEnvironment = OrtEnvironment.getEnvironment()
     }

--- a/ios/Classes/FlutterOnnxruntimePlugin.swift
+++ b/ios/Classes/FlutterOnnxruntimePlugin.swift
@@ -19,7 +19,12 @@ public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
   private var env: ORTEnv?
 
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "flutter_onnxruntime", binaryMessenger: registrar.messenger())
+    let taskQueue = registrar.messenger().makeBackgroundTaskQueue?()
+    let channel = FlutterMethodChannel(
+        name: "flutter_onnxruntime",
+        binaryMessenger: registrar.messenger(),
+        codec: FlutterStandardMethodCodec.sharedInstance(),
+        taskQueue: taskQueue)
     let instance = FlutterOnnxruntimePlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
 

--- a/macos/Classes/FlutterOnnxruntimePlugin.swift
+++ b/macos/Classes/FlutterOnnxruntimePlugin.swift
@@ -19,7 +19,13 @@ public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
   private var env: ORTEnv?
 
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "flutter_onnxruntime", binaryMessenger: registrar.messenger)
+    let messenger = registrar.messenger
+    let taskQueue = messenger.makeBackgroundTaskQueue?()
+    let channel = FlutterMethodChannel(
+        name: "flutter_onnxruntime",
+        binaryMessenger: messenger,
+        codec: FlutterStandardMethodCodec.sharedInstance(),
+        taskQueue: taskQueue)
     let instance = FlutterOnnxruntimePlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
 


### PR DESCRIPTION
## Problem

When running ML inference (e.g., YOLO object detection at ~150ms per frame), the native method channel handler blocks the platform main thread, causing visible UI freezes — even when called from a background Dart isolate via `BackgroundIsolateBinaryMessenger`.

This happens because `FlutterMethodChannel` (iOS) and `MethodChannel` (Android) dispatch incoming calls to the main thread by default.

## Solution

Use Flutter's built-in `TaskQueue` API to dispatch all method channel calls to a background thread:

**iOS** (`FlutterOnnxruntimePlugin.swift`):
```swift
let taskQueue = registrar.messenger().makeBackgroundTaskQueue?()
let channel = FlutterMethodChannel(
    name: "flutter_onnxruntime",
    binaryMessenger: registrar.messenger(),
    codec: FlutterStandardMethodCodec.sharedInstance(),
    taskQueue: taskQueue)
```

**Android** (`FlutterOnnxruntimePlugin.kt`):
```kotlin
val taskQueue = flutterPluginBinding.binaryMessenger.makeBackgroundTaskQueue()
channel = MethodChannel(
    flutterPluginBinding.binaryMessenger,
    "flutter_onnxruntime",
    StandardMethodCodec.INSTANCE,
    taskQueue)
```

## Why this approach over PR #55

- Covers **both iOS and Android** (PR #55 only fixes iOS)
- Uses the **officially supported Flutter pattern** (`TaskQueue`) instead of manual `DispatchQueue.global().async`
- Smaller diff — 2 lines changed per platform
- All method channel calls are automatically dispatched to background, not just `createSession` and `runInference`

## Testing

Tested with a real-time YOLO11n-OBB card scanner running at ~6-7 Hz on iOS. Before: visible UI freezes during detection. After: smooth camera preview and animations with zero jank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)