### PR TITLE
Add synchronization to prevent race condition during engine detach

### DIFF
--- a/android/src/main/kotlin/com/masicai/flutteronnxruntime/FlutterOnnxruntimePlugin.kt
+++ b/android/src/main/kotlin/com/masicai/flutteronnxruntime/FlutterOnnxruntimePlugin.kt
@@ -142,6 +142,9 @@ class FlutterOnnxruntimePlugin : FlutterPlugin, MethodCallHandler {
     // Store OrtValues (tensors) by ID
     private val ortValues = ConcurrentHashMap<String, OnnxValue>()
 
+    // Lock to serialize method handler and cleanup to prevent use-after-close races
+    private val lock = Any()
+
     private fun ortTypeToString(type: OnnxJavaType): String {
         return when (type.toString()) {
             "FLOAT" -> "float32"
@@ -200,7 +203,7 @@ class FlutterOnnxruntimePlugin : FlutterPlugin, MethodCallHandler {
     override fun onMethodCall(
         @NonNull call: MethodCall,
         @NonNull result: Result,
-    ) {
+    ) = synchronized(lock) {
         when (call.method) {
             "getPlatformVersion" -> {
                 result.success("Android ${android.os.Build.VERSION.RELEASE}")
@@ -1197,33 +1200,37 @@ class FlutterOnnxruntimePlugin : FlutterPlugin, MethodCallHandler {
     override fun onDetachedFromEngine(
         @NonNull binding: FlutterPlugin.FlutterPluginBinding,
     ) {
-        // Close all OrtValues
-        for (value in ortValues.values) {
-            try {
-                value.close()
-            } catch (e: Exception) {
-                // Ignore exceptions during cleanup
-            }
-        }
-        ortValues.clear()
-
-        // Close all sessions
-        for (session in sessions.values) {
-            try {
-                session.close()
-            } catch (e: Exception) {
-                // Ignore exceptions during cleanup
-            }
-        }
-        sessions.clear()
-
-        // Close the environment
-        try {
-            ortEnvironment.close()
-        } catch (e: Exception) {
-            // Ignore exceptions during cleanup
-        }
-
+        // Stop accepting new calls before acquiring the lock
         channel.setMethodCallHandler(null)
+
+        // Wait for any in-flight handler call to finish, then clean up
+        synchronized(lock) {
+            // Close all OrtValues
+            for (value in ortValues.values) {
+                try {
+                    value.close()
+                } catch (e: Exception) {
+                    // Ignore exceptions during cleanup
+                }
+            }
+            ortValues.clear()
+
+            // Close all sessions
+            for (session in sessions.values) {
+                try {
+                    session.close()
+                } catch (e: Exception) {
+                    // Ignore exceptions during cleanup
+                }
+            }
+            sessions.clear()
+
+            // Close the environment
+            try {
+                ortEnvironment.close()
+            } catch (e: Exception) {
+                // Ignore exceptions during cleanup
+            }
+        }
     }
 }

--- a/ios/Classes/FlutterOnnxruntimePlugin.swift
+++ b/ios/Classes/FlutterOnnxruntimePlugin.swift
@@ -17,6 +17,8 @@ enum OrtError: Error {
 public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
   private var sessions = [String: ORTSession]()
   private var env: ORTEnv?
+  // Lock to serialize method handler and cleanup to prevent use-after-close races
+  private let lock = NSLock()
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let taskQueue = registrar.messenger().makeBackgroundTaskQueue?()
@@ -46,6 +48,10 @@ public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
   }
 
   private func cleanupResources() {
+    // Wait for any in-flight handler call to finish, then clean up
+    lock.lock()
+    defer { lock.unlock() }
+
     // Clear all OrtValues first (they may depend on sessions/env)
     ortValues.removeAll()
 
@@ -58,6 +64,9 @@ public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
 
   // swiftlint:disable:next cyclomatic_complexity
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    lock.lock()
+    defer { lock.unlock() }
+
     if env == nil {
       do {
         env = try ORTEnv(loggingLevel: ORTLoggingLevel.warning)

--- a/macos/Classes/FlutterOnnxruntimePlugin.swift
+++ b/macos/Classes/FlutterOnnxruntimePlugin.swift
@@ -17,6 +17,8 @@ enum OrtError: Error {
 public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
   private var sessions = [String: ORTSession]()
   private var env: ORTEnv?
+  // Lock to serialize method handler and cleanup to prevent use-after-close races
+  private let lock = NSLock()
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let messenger = registrar.messenger
@@ -47,6 +49,10 @@ public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
   }
 
   private func cleanupResources() {
+    // Wait for any in-flight handler call to finish, then clean up
+    lock.lock()
+    defer { lock.unlock() }
+
     // Clear all OrtValues first (they may depend on sessions/env)
     ortValues.removeAll()
 
@@ -59,6 +65,9 @@ public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
 
   // swiftlint:disable:next cyclomatic_complexity
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    lock.lock()
+    defer { lock.unlock() }
+
     if env == nil {
       do {
         env = try ORTEnv(loggingLevel: ORTLoggingLevel.warning)


### PR DESCRIPTION
## Problem

PR #56 moved method channel dispatch from the main thread to a background task queue to eliminate UI jank during inference. However, this introduced a race condition: `onDetachedFromEngine` (Android) or `cleanupResources` (iOS/macOS) can execute on the main thread while a method call is still in-flight on the background queue, potentially closing sessions or ORT values that are actively being used.

## Solution

Introduce a per-plugin lock (`synchronized` on Android, `NSLock` on iOS/macOS) that serializes access between the method handler and cleanup path. On Android, the handler is unregistered first to stop new calls from being enqueued, then the lock ensures any in-flight call completes before resources are released.