### PR TITLE
fix: prevent startup crash from makeBackgroundTaskQueue forwarding on macOS

### DIFF
--- a/macos/Classes/FlutterOnnxruntimePlugin.swift
+++ b/macos/Classes/FlutterOnnxruntimePlugin.swift
@@ -22,7 +22,8 @@ public class FlutterOnnxruntimePlugin: NSObject, FlutterPlugin {
 
   public static func register(with registrar: FlutterPluginRegistrar) {
     let messenger = registrar.messenger
-    let taskQueue = messenger.makeBackgroundTaskQueue?()
+    // Workaround for Flutter macOS issue #184737 — see MessengerHelper.h.
+    let taskQueue = MessengerHelper.safeMakeBackgroundTaskQueue(messenger)
     let channel = FlutterMethodChannel(
         name: "flutter_onnxruntime",
         binaryMessenger: messenger,

--- a/macos/Classes/MessengerHelper.h
+++ b/macos/Classes/MessengerHelper.h
@@ -1,0 +1,27 @@
+// Copyright (c) MASIC AI
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#import <Foundation/Foundation.h>
+#import <FlutterMacOS/FlutterMacOS.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MessengerHelper : NSObject
+
+/// Attempts to create a background task queue from the given binary messenger,
+/// returning nil if the underlying engine does not implement the selector.
+///
+/// On some Flutter macOS versions, FlutterBinaryMessengerRelay declares
+/// -makeBackgroundTaskQueue but forwards it to a FlutterEngine that does not
+/// implement the selector, raising an NSInvalidArgumentException that Swift's
+/// optional chaining cannot catch. This helper wraps the call in @try/@catch.
+/// See https://github.com/flutter/flutter/issues/184737
++ (nullable NSObject<FlutterTaskQueue> *)safeMakeBackgroundTaskQueue:
+    (NSObject<FlutterBinaryMessenger> *)messenger;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/macos/Classes/MessengerHelper.mm
+++ b/macos/Classes/MessengerHelper.mm
@@ -16,10 +16,6 @@
   @try {
     return [messenger makeBackgroundTaskQueue];
   } @catch (NSException *exception) {
-    NSLog(@"[flutter_onnxruntime] makeBackgroundTaskQueue unavailable; method "
-          @"calls will run on the platform thread. Upgrade Flutter to restore "
-          @"background dispatch. (%@)",
-          exception.reason);
     return nil;
   }
 }

--- a/macos/Classes/MessengerHelper.mm
+++ b/macos/Classes/MessengerHelper.mm
@@ -1,0 +1,27 @@
+// Copyright (c) MASIC AI
+// All rights reserved.
+//
+// This source code is licensed under the license found in the
+// LICENSE file in the root directory of this source tree.
+
+#import "MessengerHelper.h"
+
+@implementation MessengerHelper
+
++ (NSObject<FlutterTaskQueue> *)safeMakeBackgroundTaskQueue:
+    (NSObject<FlutterBinaryMessenger> *)messenger {
+  if (![messenger respondsToSelector:@selector(makeBackgroundTaskQueue)]) {
+    return nil;
+  }
+  @try {
+    return [messenger makeBackgroundTaskQueue];
+  } @catch (NSException *exception) {
+    NSLog(@"[flutter_onnxruntime] makeBackgroundTaskQueue unavailable; method "
+          @"calls will run on the platform thread. Upgrade Flutter to restore "
+          @"background dispatch. (%@)",
+          exception.reason);
+    return nil;
+  }
+}
+
+@end


### PR DESCRIPTION
## Summary

Fixes #58 — macOS apps crash on startup with `NSInvalidArgumentException: -[FlutterEngine makeBackgroundTaskQueue]: unrecognized selector` since v1.7.0.

## Root cause

The `registrar.messenger` returned on macOS is a `FlutterBinaryMessengerRelay` that *declares* `-makeBackgroundTaskQueue` but forwards it to its parent `FlutterEngine`. On affected Flutter macOS versions, `FlutterEngine` does not implement that selector, so ObjC's message-forwarding machinery raises `NSInvalidArgumentException` — which Swift's optional chaining (`messenger.makeBackgroundTaskQueue?()`) cannot catch.

This is an upstream Flutter issue: flutter/flutter#184737. iOS is unaffected because iOS's `FlutterEngine` does implement the selector.

## Fix

Route the call through a small ObjC++ helper (`MessengerHelper`) that wraps the invocation in `@try/@catch` and returns `nil` when the underlying engine doesn't implement the selector. When TaskQueue is unavailable, method calls fall back to the platform thread; the plugin's existing `NSLock` keeps `handle()`/cleanup serialized. When the upstream Flutter bug is fixed, the helper transparently picks up the real TaskQueue again — no follow-up patch needed.

Note: the warning below is expected from Flutter Engine for macOS. The app's functionalities are not affected.

```bash
2026-05-16 20:04:19.343 Running with merged UI and platform thread. Experimental.
Failed to foreground app; open returned 1
```