### PR TITLE
Migrate Android plugin to Flutter Built-in Kotlin (silence KGP warning)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 1.9.0
+* Migrate the Android plugin to Flutter's Built-in Kotlin: remove `apply plugin: "kotlin-android"` and the `android { kotlinOptions { } }` block, replaced by a top-level `kotlin { compilerOptions { } }` block. This silences the "plugins that apply Kotlin Gradle Plugin (KGP)" warning on Flutter 3.44+ and keeps the plugin building on future Flutter versions that drop implicit KGP support. Requires Flutter `>=3.44.0`.
+
 ## 1.8.0
 * Add Swift Package Manager support for iOS and macOS (#62); CocoaPods remains fully supported
 * Upgrade `onnxruntime-objc` from 1.22.0 to 1.24.2 for iOS and macOS (aligned with the official ONNX Runtime Swift package)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -22,7 +22,6 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
 
 android {
     namespace = "com.masicai.flutteronnxruntime"
@@ -32,10 +31,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_11
     }
 
     sourceSets {
@@ -64,5 +59,15 @@ android {
                showStandardStreams = true
             }
         }
+    }
+}
+
+// KGP is no longer applied here; Flutter's Built-in Kotlin (3.44+) auto-applies the
+// Kotlin Gradle Plugin for plugin modules. This replaces the old
+// `android { kotlinOptions { jvmTarget } }` block.
+// See https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11
     }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,12 @@
 name: flutter_onnxruntime
 description: "A lightweight plugin that provides native wrappers for running ONNX Runtime on multiple platforms"
-version: 1.8.0
+version: 1.9.0
 homepage: https://github.com/masicai/flutter_onnxruntime
 repository: https://github.com/masicai/flutter_onnxruntime
 
 environment:
   sdk: ^3.7.0
-  flutter: '>=3.3.0'
+  flutter: '>=3.44.0'
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Problem

On Flutter 3.44+, any app depending on `flutter_onnxruntime` prints this warning on every build/run:

```
WARNING: Your app uses the following plugins that apply Kotlin Gradle Plugin (KGP): flutter_onnxruntime
Future versions of Flutter will fail to build if your app uses plugins that apply KGP.
```

It comes from `android/build.gradle`, which applies KGP directly via `apply plugin: "kotlin-android"`. Flutter's tooling detects this in the plugin's build script and warns; future Flutter versions will **fail the build** rather than warn. (First-party plugins like `camera_android_camerax`, `image_picker_android` and `local_auth_android` have already migrated.)

## Change

Migrates the Android plugin to **Built-in Kotlin**, following the official guide for plugin authors:
https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors

- Remove `apply plugin: "kotlin-android"` — Flutter auto-applies the Kotlin Gradle Plugin for plugin modules on 3.44+.
- Remove the `android { kotlinOptions { jvmTarget } }` block and replace it with a top-level `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_11 } }` block.
- Bump the minimum Flutter to `>=3.44.0` in `pubspec.yaml` (see compatibility note below).
- CHANGELOG entry (provisionally `1.9.0` — feel free to re-version).

## Compatibility note (your call)

Built-in Kotlin requires **Flutter 3.44+**. Dropping `apply plugin: "kotlin-android"` means the plugin no longer applies KGP on its own, so it would not compile on Flutter `< 3.44`. I bumped the `flutter` constraint from `>=3.3.0` to `>=3.44.0` accordingly. If you'd rather keep supporting older Flutter for now, that's a maintainer decision — happy to adjust the approach.

## Validation

Built locally against Flutter 3.44.3 (Dart 3.12.2) in a real app that uses this plugin:

- `./gradlew :flutter_onnxruntime:compileDebugKotlin` → **BUILD SUCCESSFUL** (compiles with Built-in Kotlin).
- The `plugins that apply Kotlin Gradle Plugin (KGP): flutter_onnxruntime` warning is **gone**.
